### PR TITLE
Add sorting to DSUI tables via headers

### DIFF
--- a/lib/middlewares/ds.js
+++ b/lib/middlewares/ds.js
@@ -108,7 +108,7 @@ class DS {
             );
             let sortedQuery = query;
             if (orderfield) {
-                orderdesc = orderdesc ? orderdesc : false;
+                orderdesc = (orderdesc == 'false') ? true : false;
                 sortedQuery = query.order(orderfield, { descending: orderdesc, });
             }
             [items] = await this._datastore.runQuery(sortedQuery);

--- a/lib/middlewares/ds.js
+++ b/lib/middlewares/ds.js
@@ -81,11 +81,11 @@ class DS {
         } catch (e) {
             return string;
         }
-        
+
     }
 
     async getEntities(options) {
-        let { kind, page, itemsPerPage, namespace } = options
+        let { kind, page, itemsPerPage, namespace, orderfield, orderdesc } = options
         page = parseInt(page, 10);
         page = isNaN(page) ? 1 : page;
         let totalPages = 1;
@@ -106,7 +106,12 @@ class DS {
                 (q, f) => q.filter(f, '=', options[f]),
                 this._datastore.createQuery(...queryArgs)
             );
-            [items] = await this._datastore.runQuery(query);
+            let sortedQuery = query;
+            if (orderfield) {
+                orderdesc = orderdesc ? orderdesc : false;
+                sortedQuery = query.order(orderfield, { descending: orderdesc, });
+            }
+            [items] = await this._datastore.runQuery(sortedQuery);
             if (isAll) {
                 start = 0;
                 end = items.length

--- a/lib/public/stylesheets/style.css
+++ b/lib/public/stylesheets/style.css
@@ -16,6 +16,14 @@ td, th {
     max-width: 30rem;
 }
 
+th a {
+    color: white;
+}
+
+th a:hover {
+    color: white;
+}
+
 body > .container-fluid {
 
 }

--- a/lib/public/stylesheets/style.css
+++ b/lib/public/stylesheets/style.css
@@ -16,14 +16,6 @@ td, th {
     max-width: 30rem;
 }
 
-th a {
-    color: white;
-}
-
-th a:hover {
-    color: white;
-}
-
 body > .container-fluid {
 
 }

--- a/lib/views/index.pug
+++ b/lib/views/index.pug
@@ -2,8 +2,11 @@ extends layout
 include ./mixins/pagination.pug
 
 block content
-	
+
 	input(type='hidden' name='page' value=entities.currentPage onchange='form.submit()' form='form')
+	input(type='hidden' name='orderfield' value=query.orderfield onchange='form.submit()' form='form')
+	input(type='hidden' name='orderdesc' value=query.orderdesc onchange='form.submit()' form='form')
+
 	.form-row.justify-content
 		.form-group.col.flex-grow-1
 			label(for='namespace') Namespace
@@ -35,9 +38,9 @@ block content
 						th(scope="col") Key
 						each field in entities.fields
 							- if (!/^_key/.test(field))
-								th(scope='col') #{field}
+								th(scope='col', onclick='onHeaderClick("'+field+'")') #{field}
 				tbody
-					each item, index in entities.items 
+					each item, index in entities.items
 						tr
 							th(scope="row")
 								input.entity-checkbox(id=`checkbox${index}` type='checkbox' value=item._keyURIComponent name='keys' form='deleteForm' onchange='adjustDeleteButton()')
@@ -53,7 +56,7 @@ block content
 				select#itemsPerPage(name='itemsPerPage' onchange='form.page.value=1; form.submit();' form='form')
 					each ipp in ['5', '10', '20', '50', '100', '200', 'all']
 						option(value=ipp selected=(ipp == query.itemsPerPage)) #{ipp}
-		
+
 	else
 		| No entities
 	form#form.d-none(action='' method='get')
@@ -73,6 +76,15 @@ block script
 		function onAllCheckboxChange() {
 			Array.from(document.querySelectorAll(".entity-checkbox")).forEach(el => el.checked = event.target.checked);
 			adjustDeleteButton();
+		}
+
+		function onHeaderClick(field) {
+			if (form.orderfield.value!==field) {
+				form.orderfield.value=field;
+			} else {
+				form.orderdesc.value = (form.orderdesc.value == 'false') ? true : false;
+			}
+			form.submit();
 		}
 
 		function onDeleteClick() {


### PR DESCRIPTION
This PR adds the ability to sort in DSUI by clicking on the headers; a first click switches to that field, and subsequent clicks reverse the sort order. Sort order persists through paging.

Note this is not yet exercised in the tests.